### PR TITLE
Added random title assignment on zone change

### DIFF
--- a/Configuration.cs
+++ b/Configuration.cs
@@ -10,6 +10,9 @@ public sealed class Configuration : IPluginConfiguration
 
     #region Saved configuration values
 
+    public TitleGroup randomTitleGroup { get; set; }
+    public bool       assignRandomTitleOnAreaChange { get; set; }
+
     public Dictionary<ulong, List<TitleGroup>> TitleGroups { get; set; } = new();
     public bool ShowErrorOnEmptyGroup { get; set; } = true;
     public bool ShowErrorOnMissingGroup { get; set; } = true;

--- a/Configuration.cs
+++ b/Configuration.cs
@@ -10,7 +10,7 @@ public sealed class Configuration : IPluginConfiguration
 
     #region Saved configuration values
 
-    public TitleGroup randomTitleGroup { get; set; }
+    public bool AssignRandomTitleOnAreaChange { get; set; }
     public bool       assignRandomTitleOnAreaChange { get; set; }
 
     public Dictionary<ulong, List<TitleGroup>> TitleGroups { get; set; } = new();

--- a/Configuration.cs
+++ b/Configuration.cs
@@ -11,7 +11,6 @@ public sealed class Configuration : IPluginConfiguration
     #region Saved configuration values
 
     public bool AssignRandomTitleOnAreaChange { get; set; }
-    public bool       assignRandomTitleOnAreaChange { get; set; }
 
     public Dictionary<ulong, List<TitleGroup>> TitleGroups { get; set; } = new();
     public bool ShowErrorOnEmptyGroup { get; set; } = true;

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -36,7 +36,8 @@ public sealed class Plugin : IDalamudPlugin
 
     private void RandomTitleEvent()
     {
-        SetRandomTitleFromGroup(Service.Configuration.randomTitleGroup);
+        if(Service.Configuration.assignRandomTitleOnAreaChange)
+            SetRandomTitleFromGroup(Service.Configuration.randomTitleGroup);
     }
 
     private void EnsureBasicConfiguration()

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -36,8 +36,8 @@ public sealed class Plugin : IDalamudPlugin
 
     private void RandomTitleEvent(ushort _)
     {
-        if(Service.Configuration.assignRandomTitleOnAreaChange)
-            SetRandomTitleFromGroup(Service.Configuration.randomTitleGroup);
+        if(Service.Configuration.AssignRandomTitleOnAreaChange) 
+            PickRandomTitle(string.Empty, string.Empty);
     }
 
     private void EnsureBasicConfiguration()

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -31,6 +31,12 @@ public sealed class Plugin : IDalamudPlugin
         {
             HelpMessage = "Configures which titles are used in title roulette."
         });
+        Service.ClientState.TerritoryChanged += _ => RandomTitleEvent();
+    }
+
+    private void RandomTitleEvent()
+    {
+        SetRandomTitleFromGroup(Service.Configuration.randomTitleGroup);
     }
 
     private void EnsureBasicConfiguration()
@@ -104,20 +110,24 @@ public sealed class Plugin : IDalamudPlugin
                 return;
             }
         }
+        SetRandomTitleFromGroup(group);
+    }
 
+    private void SetRandomTitleFromGroup(Configuration.TitleGroup group)
+    {
         int titleCount = group.Titles.Count;
         if (titleCount == 0)
         {
             if (Service.Configuration.ShowErrorOnEmptyGroup)
             {
                 Service.Chat.PrintError(
-                    $"[Title Roulette] Can't pick a random title from group '{args}' as it is empty.");
+                                        $"[Title Roulette] Can't pick a random title from group '{group.Name}' as it is empty.");
             }
 
             return;
         }
 
-        ushort currentTitleId = Service.GameFunctions.GetCurrentTitleId();
+        ushort       currentTitleId  = Service.GameFunctions.GetCurrentTitleId();
         List<ushort> differentTitles = group.Titles.Where(v => v != currentTitleId).ToList();
         if (differentTitles.Count > 0)
         {

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -31,10 +31,10 @@ public sealed class Plugin : IDalamudPlugin
         {
             HelpMessage = "Configures which titles are used in title roulette."
         });
-        Service.ClientState.TerritoryChanged += _ => RandomTitleEvent();
+        Service.ClientState.TerritoryChanged += RandomTitleEvent;
     }
 
-    private void RandomTitleEvent()
+    private void RandomTitleEvent(ushort _)
     {
         if(Service.Configuration.assignRandomTitleOnAreaChange)
             SetRandomTitleFromGroup(Service.Configuration.randomTitleGroup);
@@ -160,5 +160,6 @@ public sealed class Plugin : IDalamudPlugin
         Service.PluginInterface.UiBuilder.OpenConfigUi -= OpenConfigWindow;
         Service.PluginInterface.UiBuilder.OpenMainUi -= OpenMainWindow;
         Service.PluginInterface.UiBuilder.Draw -= Service.WindowSystem.Draw;
+        Service.ClientState.TerritoryChanged -= RandomTitleEvent;
     }
 }

--- a/PluginWindow.cs
+++ b/PluginWindow.cs
@@ -162,9 +162,9 @@ internal sealed class PluginWindow : Window
         private int _currentGroup;
         private         int                            currentGroupForRandom = 0;
 
-        public required List<Configuration.TitleGroup> Groups       { get; set; }
-        public required List<Title>                    SortedTitles { get; set; }
-        public required bool                           IsFemale     { get; set; }
+        public required List<Configuration.TitleGroup> Groups { get; set; }
+        public required List<Title> SortedTitles { get; set; }
+        public required bool IsFemale { get; set; }
 
         public void Draw(out bool manageGroups, out bool close)
         {
@@ -288,7 +288,7 @@ internal sealed class PluginWindow : Window
                 ImGui.SetTooltip("Hold CTRL to discard any changes you've made since you've last saved.");
 
             ImGui.SameLine();
-            bool randomAssign = Service.Configuration.assignRandomTitleOnAreaChange;
+            bool randomAssign = Service.Configuration.AssignRandomTitleOnAreaChange;
             if (ImGui.Checkbox("Random title when switching Zones", ref randomAssign))
                 save = true;
             Service.Configuration.assignRandomTitleOnAreaChange = randomAssign;

--- a/PluginWindow.cs
+++ b/PluginWindow.cs
@@ -289,7 +289,8 @@ internal sealed class PluginWindow : Window
 
             ImGui.SameLine();
             bool randomAssign = Service.Configuration.assignRandomTitleOnAreaChange;
-            ImGui.Checkbox("Random title when switching Zones", ref randomAssign);
+            if (ImGui.Checkbox("Random title when switching Zones", ref randomAssign))
+                save = true;
             Service.Configuration.assignRandomTitleOnAreaChange = randomAssign;
 
             if (randomAssign)
@@ -304,6 +305,7 @@ internal sealed class PluginWindow : Window
                         {
                             currentGroupForRandom                  = i;
                             Service.Configuration.randomTitleGroup = Groups[currentGroupForRandom];
+                            save                                   = true;
                         }
                     }
                     ImGui.EndCombo();

--- a/PluginWindow.cs
+++ b/PluginWindow.cs
@@ -160,10 +160,11 @@ internal sealed class PluginWindow : Window
     internal sealed class TitleSelection
     {
         private int _currentGroup;
+        private         int                            currentGroupForRandom = 0;
 
-        public required List<Configuration.TitleGroup> Groups { get; set; }
-        public required List<Title> SortedTitles { get; set; }
-        public required bool IsFemale { get; set; }
+        public required List<Configuration.TitleGroup> Groups       { get; set; }
+        public required List<Title>                    SortedTitles { get; set; }
+        public required bool                           IsFemale     { get; set; }
 
         public void Draw(out bool manageGroups, out bool close)
         {
@@ -285,6 +286,29 @@ internal sealed class PluginWindow : Window
             ImGui.EndDisabled();
             if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled) && !ImGui.GetIO().KeyCtrl)
                 ImGui.SetTooltip("Hold CTRL to discard any changes you've made since you've last saved.");
+
+            ImGui.SameLine();
+            bool randomAssign = Service.Configuration.assignRandomTitleOnAreaChange;
+            ImGui.Checkbox("Random title when switching Zones", ref randomAssign);
+            Service.Configuration.assignRandomTitleOnAreaChange = randomAssign;
+
+            if (randomAssign)
+            {
+                ImGui.SameLine();
+                ImGui.SetNextItemWidth(200);
+                if (ImGui.BeginCombo("###GroupComboRandom", $"{Groups[currentGroupForRandom].Name} ({FormatTitleCount(Groups[currentGroupForRandom])})"))
+                {
+                    for (int i = 0; i < Groups.Count; ++i)
+                    {
+                        if (ImGui.Selectable($"{Groups[i].Name} ({FormatTitleCount(Groups[i])})", i == currentGroupForRandom))
+                        {
+                            currentGroupForRandom                  = i;
+                            Service.Configuration.randomTitleGroup = Groups[currentGroupForRandom];
+                        }
+                    }
+                    ImGui.EndCombo();
+                }
+            }
 
             if (save)
             {

--- a/PluginWindow.cs
+++ b/PluginWindow.cs
@@ -160,7 +160,6 @@ internal sealed class PluginWindow : Window
     internal sealed class TitleSelection
     {
         private int _currentGroup;
-        private         int                            currentGroupForRandom = 0;
 
         public required List<Configuration.TitleGroup> Groups { get; set; }
         public required List<Title> SortedTitles { get; set; }
@@ -290,26 +289,9 @@ internal sealed class PluginWindow : Window
             ImGui.SameLine();
             bool randomAssign = Service.Configuration.AssignRandomTitleOnAreaChange;
             if (ImGui.Checkbox("Random title when switching Zones", ref randomAssign))
-                save = true;
-            Service.Configuration.assignRandomTitleOnAreaChange = randomAssign;
-
-            if (randomAssign)
             {
-                ImGui.SameLine();
-                ImGui.SetNextItemWidth(200);
-                if (ImGui.BeginCombo("###GroupComboRandom", $"{Groups[currentGroupForRandom].Name} ({FormatTitleCount(Groups[currentGroupForRandom])})"))
-                {
-                    for (int i = 0; i < Groups.Count; ++i)
-                    {
-                        if (ImGui.Selectable($"{Groups[i].Name} ({FormatTitleCount(Groups[i])})", i == currentGroupForRandom))
-                        {
-                            currentGroupForRandom                  = i;
-                            Service.Configuration.randomTitleGroup = Groups[currentGroupForRandom];
-                            save                                   = true;
-                        }
-                    }
-                    ImGui.EndCombo();
-                }
+                save = true;
+                Service.Configuration.AssignRandomTitleOnAreaChange = randomAssign;
             }
 
             if (save)

--- a/TitleRoulette.sln
+++ b/TitleRoulette.sln
@@ -7,14 +7,14 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TitleRoulette", "TitleRoule
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{EC98CE71-953A-442B-9943-AB6EA57167D3}.Debug|Any CPU.ActiveCfg = Debug|x64
-		{EC98CE71-953A-442B-9943-AB6EA57167D3}.Debug|Any CPU.Build.0 = Debug|x64
-		{EC98CE71-953A-442B-9943-AB6EA57167D3}.Release|Any CPU.ActiveCfg = ExportRelease|x64
-		{EC98CE71-953A-442B-9943-AB6EA57167D3}.Release|Any CPU.Build.0 = ExportRelease|x64
+		{EC98CE71-953A-442B-9943-AB6EA57167D3}.Debug|x64.ActiveCfg = Debug|x64
+		{EC98CE71-953A-442B-9943-AB6EA57167D3}.Debug|x64.Build.0 = Debug|x64
+		{EC98CE71-953A-442B-9943-AB6EA57167D3}.Release|x64.ActiveCfg = Release|x64
+		{EC98CE71-953A-442B-9943-AB6EA57167D3}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/TitleRoulette.sln
+++ b/TitleRoulette.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.4.33122.133
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TitleRoulette", "TitleRoulette.csproj", "{EC98CE71-953A-442B-9943-AB6EA57167D3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TitleRoulette", "TitleRoulette.csproj", "{EC98CE71-953A-442B-9943-AB6EA57167D3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -11,10 +11,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{EC98CE71-953A-442B-9943-AB6EA57167D3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{EC98CE71-953A-442B-9943-AB6EA57167D3}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EC98CE71-953A-442B-9943-AB6EA57167D3}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{EC98CE71-953A-442B-9943-AB6EA57167D3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EC98CE71-953A-442B-9943-AB6EA57167D3}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{EC98CE71-953A-442B-9943-AB6EA57167D3}.Debug|Any CPU.Build.0 = Debug|x64
+		{EC98CE71-953A-442B-9943-AB6EA57167D3}.Release|Any CPU.ActiveCfg = ExportRelease|x64
+		{EC98CE71-953A-442B-9943-AB6EA57167D3}.Release|Any CPU.Build.0 = ExportRelease|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Had this feature in my fork even back when liza had the plugin.

Basically, this allows you to select a TitleGroup that is used on each zone switch to randomly assign a title.

Since there is now a 1pp doing automatic title edits, this doesn't seem that different.
For context: The 1pp plugin `JobTitles` automatically changes titles upon job switch.
![image](https://github.com/user-attachments/assets/3da98357-69c8-4dc3-b8a5-0b32adacff92)
